### PR TITLE
Consider radix sort

### DIFF
--- a/src/main/java/org/fastfilter/gcs/Sort.java
+++ b/src/main/java/org/fastfilter/gcs/Sort.java
@@ -9,23 +9,25 @@ public class Sort {
     }
 
     public static void sortUnsigned(long[] data, int offset, int len) {
-        int left = offset, right = offset + len - 1;
-        while(true) {
-            while (left < data.length && data[left] >= 0) {
-                left++;
+        int[] histogram = new int[257];
+        int shift = 0;
+        long mask = 0xFF;
+        long[] buffer = new long[Math.min(len, data.length)];
+        while (shift < Long.SIZE) {
+            Arrays.fill(histogram, 0);
+            for (int i = offset; i + offset < buffer.length; ++i) {
+                ++histogram[(int)((data[i] & mask) >>> shift) + 1];
             }
-            while (right > 0 && data[right] < 0) {
-                right--;
+            for (int i = 0; i + 1 < histogram.length; ++i) {
+                histogram[i + 1] += histogram[i];
             }
-            if (left >= right) {
-                break;
+            for (int i = offset; i + offset < buffer.length; ++i) {
+                buffer[histogram[(int)((data[i] & mask) >>> shift)]++] = data[i];
             }
-            long temp = data[left];
-            data[left++] = data[right];
-            data[right--] = temp;
+            System.arraycopy(buffer, 0, data, offset, buffer.length);
+            shift += 8;
+            mask <<= 8;
         }
-        Arrays.sort(data, offset, left);
-        Arrays.sort(data, left, len);
     }
 
 }


### PR DESCRIPTION
This unsigned sort is approximately twice as fast on my system according to your existing benchmarks.

Before:

```
test 0
sorted in 17.841520925 secs
compared
test 1
sorted in 19.546578784 secs
compared
test 2
sorted in 18.674980217 secs
compared
test 3
sorted in 18.138397684 secs
compared
```

After:

```
test 0
sorted in 7.32589919 secs
compared
test 1
sorted in 7.90555295 secs
compared
test 2
sorted in 7.055289701 secs
compared
test 3
sorted in 7.201343685 secs
compared
```
