### PR TITLE
Cleanup XorPlus8 + guard against infinite loop in table construction

### DIFF
--- a/fastfilter/src/main/java/org/fastfilter/xorplus/XorPlus8.java
+++ b/fastfilter/src/main/java/org/fastfilter/xorplus/XorPlus8.java
@@ -67,13 +67,15 @@ public class XorPlus8 implements Filter {
     }
 
     /**
-     * Calculate the table (array) length. This is 1.23 times the size, plus an offset of 32 (see paper, Fig. 1)
+     * Calculate the table (array) length. This is 1.23 times the size, plus an offset of 32 (see paper, Fig. 1).
+     * We round down to a multiple of HASHES, as any excess entries couldn't be used.
      *
      * @param size the number of entries
      * @return the table length
      */
     private static int getArrayLength(int size) {
-        return (int) (OFFSET + (long) FACTOR_TIMES_100 * size / 100);
+        int arrayLength = (int) (OFFSET + (long) FACTOR_TIMES_100 * size / 100);
+        return arrayLength - (arrayLength % HASHES);
     }
 
     public static XorPlus8 construct(long[] keys) {

--- a/fastfilter/src/main/java/org/fastfilter/xorplus/XorPlus8.java
+++ b/fastfilter/src/main/java/org/fastfilter/xorplus/XorPlus8.java
@@ -118,7 +118,14 @@ public class XorPlus8 implements Filter {
         // we usually execute this loop just once. If we detect a cycle (which is extremely unlikely)
         // then we try again, with a new random seed.
         long seed = 0;
+        int attempts = 0;
         do {
+            attempts++;
+            if (attempts >= 100) {
+                // if the same key appears more than once in the keys array, every attempt to build the table will yield a collision
+                throw new IllegalArgumentException("Unable to construct the table after 100 attempts; likely indicates duplicate keys");
+            }
+
             seed = Hash.randomSeed();
             // we use an second table t2 to keep the list of all keys that map
             // to a given entry (with a broken hash function, all keys could map

--- a/fastfilter/src/main/java/org/fastfilter/xorplus/XorPlus8.java
+++ b/fastfilter/src/main/java/org/fastfilter/xorplus/XorPlus8.java
@@ -82,14 +82,6 @@ public class XorPlus8 implements Filter {
         return new XorPlus8(keys);
     }
 
-    public XorPlus8(int size, byte[] fingerprints) {
-        this.size = size;
-        this.arrayLength = getArrayLength(size);
-        this.bitCount = arrayLength * BITS_PER_FINGERPRINT;
-        this.blockLength = arrayLength / HASHES;
-        this.fingerprints = fingerprints;
-    }
-
     /**
      * Construct the filter. This is basically the BDZ algorithm. The algorithm
      * itself is basically the same as BDZ, except that xor is used to store the
@@ -110,7 +102,6 @@ public class XorPlus8 implements Filter {
     public XorPlus8(long[] keys) {
         this.size = keys.length;
         this.arrayLength = getArrayLength(size);
-        this.bitCount = arrayLength * BITS_PER_FINGERPRINT;
         this.blockLength = arrayLength / HASHES;
         int m = arrayLength;
 
@@ -366,10 +357,10 @@ public class XorPlus8 implements Filter {
             DataInputStream din = new DataInputStream(in);
             size = din.readInt();
             arrayLength = getArrayLength(size);
-            bitCount = arrayLength * BITS_PER_FINGERPRINT;
             blockLength = arrayLength / HASHES;
             seed = din.readLong();
             int fingerprintLength = din.readInt();
+            bitCount = fingerprintLength * BITS_PER_FINGERPRINT;
             fingerprints = new byte[fingerprintLength];
             din.readFully(fingerprints);
             rank = new Rank9(din);


### PR DESCRIPTION
This PR contains some minor changes to the `XorPlus8` class:

- Update / clarify a few comments.
- More consistent use of `this.` when assigning instance fields in constructor
- Round the table length down to a multiple of 3, as any additional entries are wasted
- More consistent computation of `bitCount`; remove an unused constructor that was assigning it incorrectly
- Guard against infinite loops during table construction (could be caused by code bugs or bad input)

Regarding the unused constructor that I removed: it did not populate `seed` or `rank`, and I believe the latter means that any attempt to use the instance created by this constructor would have resulted in `NullPointerException`.

The changes are small, but can most easily be reviewed one commit at a time.