### PR TITLE
Fixing issue 40.

### DIFF
--- a/fastfilter/src/main/java/org/fastfilter/utils/Hash.java
+++ b/fastfilter/src/main/java/org/fastfilter/utils/Hash.java
@@ -32,7 +32,7 @@ public class Hash {
      */
     public static int reduce(int hash, int n) {
         // http://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
-        return (int) (((hash & 0xffffffffL) * n) >>> 32);
+        return (int) (((hash & 0xffffffffL) * (n & 0xffffffffL)) >>> 32);
     }
 
     /**

--- a/fastfilter/src/test/java/org/fastfilter/RegressionTests.java
+++ b/fastfilter/src/test/java/org/fastfilter/RegressionTests.java
@@ -79,4 +79,12 @@ public class RegressionTests {
             assertTrue(filter.mayContain(key));
         }
     }
+
+    @Test
+    public void issue40() {
+        long hash = 4282432426L;
+        long n = 2400000016L; // important: exceeds 2147483647
+        long r = (long)(Hash.reduce((int)hash, (int)n) & 0xffffffffL);
+        assertTrue(r < n);
+    }
 }

--- a/fastfilter/src/test/java/org/fastfilter/TestAllFilters.java
+++ b/fastfilter/src/test/java/org/fastfilter/TestAllFilters.java
@@ -183,9 +183,6 @@ public class TestAllFilters {
             }
             time = System.nanoTime() - time;
             nanosPerRemove = time / len;
-if (f.cardinality() != 0) {
-    System.out.println(f.cardinality());
-}
             assertEquals(f.toString(), 0, f.cardinality());
         }
         if (log) {


### PR DESCRIPTION
Fixes https://github.com/FastFilter/fastfilter_java/issues/40

It is a simple matter of the reduction algorithm overflowing when a variable is too large. I have added a reduction test.