### PR TITLE
Xor: implement stream serialization

### DIFF
--- a/fastfilter/src/main/java/org/fastfilter/Filter.java
+++ b/fastfilter/src/main/java/org/fastfilter/Filter.java
@@ -1,5 +1,7 @@
 package org.fastfilter;
 
+import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 
 /**
@@ -83,6 +85,17 @@ public interface Filter {
      * @throws UnsupportedOperationException if the operation is not supported by the filter implementation
      */
     default void serialize(ByteBuffer buffer) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Serializes the filter state into the provided {@code OutputStream}.
+     *
+     * @param out the output stream where the serialized state of the filter will be written
+     * @throws IOException if writing to the stream fails
+     * @throws UnsupportedOperationException if the operation is not supported by the filter implementation
+     */
+    default void serialize(OutputStream out) throws IOException {
         throw new UnsupportedOperationException();
     }
 }

--- a/fastfilter/src/main/java/org/fastfilter/xor/Xor16.java
+++ b/fastfilter/src/main/java/org/fastfilter/xor/Xor16.java
@@ -1,5 +1,10 @@
 package org.fastfilter.xor;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 
 import org.fastfilter.Filter;
@@ -197,6 +202,29 @@ public class Xor16 implements Filter {
 
         final int bitCount = len * BITS_PER_FINGERPRINT;
 
+        return new Xor16(blockLength, bitCount, seed, fingerprints);
+    }
+
+    public void serialize(OutputStream out) throws IOException {
+        DataOutputStream dout = new DataOutputStream(out);
+        dout.writeInt(blockLength);
+        dout.writeLong(seed);
+        dout.writeInt(fingerprints.length);
+        for (final short fp : fingerprints) {
+            dout.writeShort(fp);
+        }
+    }
+
+    public static Xor16 deserialize(InputStream in) throws IOException {
+        DataInputStream din = new DataInputStream(in);
+        final int blockLength = din.readInt();
+        final long seed = din.readLong();
+        final int len = din.readInt();
+        final short[] fingerprints = new short[len];
+        for (int i = 0; i < len; i++) {
+            fingerprints[i] = din.readShort();
+        }
+        final int bitCount = len * BITS_PER_FINGERPRINT;
         return new Xor16(blockLength, bitCount, seed, fingerprints);
     }
 }

--- a/fastfilter/src/main/java/org/fastfilter/xor/Xor8.java
+++ b/fastfilter/src/main/java/org/fastfilter/xor/Xor8.java
@@ -241,4 +241,22 @@ public class Xor8 implements Filter {
 
         return new Xor8(size, seed, fingerprints);
     }
+
+    public void serialize(OutputStream out) throws IOException {
+        DataOutputStream dout = new DataOutputStream(out);
+        dout.writeInt(size);
+        dout.writeLong(seed);
+        dout.writeInt(fingerprints.length);
+        dout.write(fingerprints);
+    }
+
+    public static Xor8 deserialize(InputStream in) throws IOException {
+        DataInputStream din = new DataInputStream(in);
+        final int size = din.readInt();
+        final long seed = din.readLong();
+        final int len = din.readInt();
+        final byte[] fingerprints = new byte[len];
+        din.readFully(fingerprints);
+        return new Xor8(size, seed, fingerprints);
+    }
 }

--- a/fastfilter/src/main/java/org/fastfilter/xor/XorBinaryFuse16.java
+++ b/fastfilter/src/main/java/org/fastfilter/xor/XorBinaryFuse16.java
@@ -1,5 +1,10 @@
 package org.fastfilter.xor;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import org.fastfilter.Filter;
@@ -323,6 +328,31 @@ public class XorBinaryFuse16 implements Filter {
         // Calculate segmentCount from segmentCountLength and segmentLength
         final int segmentCount = segmentCountLength / segmentLength;
 
+        return new XorBinaryFuse16(segmentCount, segmentLength, seed, fingerprints);
+    }
+
+    public void serialize(OutputStream out) throws IOException {
+        DataOutputStream dout = new DataOutputStream(out);
+        dout.writeInt(segmentLength);
+        dout.writeInt(segmentCountLength);
+        dout.writeLong(seed);
+        dout.writeInt(fingerprints.length);
+        for (final short fp : fingerprints) {
+            dout.writeShort(fp);
+        }
+    }
+
+    public static XorBinaryFuse16 deserialize(InputStream in) throws IOException {
+        DataInputStream din = new DataInputStream(in);
+        final int segmentLength = din.readInt();
+        final int segmentCountLength = din.readInt();
+        final long seed = din.readLong();
+        final int len = din.readInt();
+        final short[] fingerprints = new short[len];
+        for (int i = 0; i < len; i++) {
+            fingerprints[i] = din.readShort();
+        }
+        final int segmentCount = segmentCountLength / segmentLength;
         return new XorBinaryFuse16(segmentCount, segmentLength, seed, fingerprints);
     }
 }

--- a/fastfilter/src/main/java/org/fastfilter/xor/XorBinaryFuse32.java
+++ b/fastfilter/src/main/java/org/fastfilter/xor/XorBinaryFuse32.java
@@ -1,5 +1,10 @@
 package org.fastfilter.xor;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
@@ -311,6 +316,31 @@ public class XorBinaryFuse32 implements Filter {
         // Calculate segmentCount from segmentCountLength and segmentLength
         final int segmentCount = segmentCountLength / segmentLength;
 
+        return new XorBinaryFuse32(segmentCount, segmentLength, seed, fingerprints);
+    }
+
+    public void serialize(OutputStream out) throws IOException {
+        DataOutputStream dout = new DataOutputStream(out);
+        dout.writeInt(segmentLength);
+        dout.writeInt(segmentCountLength);
+        dout.writeLong(seed);
+        dout.writeInt(fingerprints.length);
+        for (final int fp : fingerprints) {
+            dout.writeInt(fp);
+        }
+    }
+
+    public static XorBinaryFuse32 deserialize(InputStream in) throws IOException {
+        DataInputStream din = new DataInputStream(in);
+        final int segmentLength = din.readInt();
+        final int segmentCountLength = din.readInt();
+        final long seed = din.readLong();
+        final int len = din.readInt();
+        final int[] fingerprints = new int[len];
+        for (int i = 0; i < len; i++) {
+            fingerprints[i] = din.readInt();
+        }
+        final int segmentCount = segmentCountLength / segmentLength;
         return new XorBinaryFuse32(segmentCount, segmentLength, seed, fingerprints);
     }
 }

--- a/fastfilter/src/main/java/org/fastfilter/xor/XorBinaryFuse8.java
+++ b/fastfilter/src/main/java/org/fastfilter/xor/XorBinaryFuse8.java
@@ -1,5 +1,10 @@
 package org.fastfilter.xor;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
@@ -319,6 +324,27 @@ public class XorBinaryFuse8 implements Filter {
         // Calculate segmentCount from segmentCountLength and segmentLength
         final int segmentCount = segmentCountLength / segmentLength;
 
+        return new XorBinaryFuse8(segmentCount, segmentLength, seed, fingerprints);
+    }
+
+    public void serialize(OutputStream out) throws IOException {
+        DataOutputStream dout = new DataOutputStream(out);
+        dout.writeInt(segmentLength);
+        dout.writeInt(segmentCountLength);
+        dout.writeLong(seed);
+        dout.writeInt(fingerprints.length);
+        dout.write(fingerprints);
+    }
+
+    public static XorBinaryFuse8 deserialize(InputStream in) throws IOException {
+        DataInputStream din = new DataInputStream(in);
+        final int segmentLength = din.readInt();
+        final int segmentCountLength = din.readInt();
+        final long seed = din.readLong();
+        final int len = din.readInt();
+        final byte[] fingerprints = new byte[len];
+        din.readFully(fingerprints);
+        final int segmentCount = segmentCountLength / segmentLength;
         return new XorBinaryFuse8(segmentCount, segmentLength, seed, fingerprints);
     }
 }


### PR DESCRIPTION
There are already methods operating on ByteBuffer, however versions taking streams allow to avoid data copying, and are more directly compatible with various network APIs. Also, for reference, Guava Bloom filter implementation uses streams.

There's a bit of code duplication as the result. Sadly, there's no standard class to wrap ByteBuffer in a stream, and pulling in an external dependency seems like an overkill here.